### PR TITLE
fix an readme empty link

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ See the [FitBit sample](samples/FitBit.gs) for the complete code.
 #### Modifying the access token payload
 
 Some OAuth providers, such as the Smartsheet API, require you to
-[add a hash to the access token request payloads]().
+[add a hash to the access token request payloads](https://smartsheet-platform.github.io/api-docs/#request-an-access-token).
 The `setTokenPayloadHandler` method allows you to pass in a function to modify
 the payload of an access token request before the request is sent to the token
 endpoint:


### PR DESCRIPTION
Fix the empty link to Smartsheet API docs

```sh
FILE: ./README.md
[✓] https://travis-ci.org/googleworkspace/apps-script-oauth2
[✓] https://travis-ci.org/googleworkspace/apps-script-oauth2.svg?branch=master
[✓] https://developers.google.com/apps-script/reference/script/state-token-builder
[✓] https://developers.google.com/apps-script/reference/calendar/
[✓] https://developers.google.com/apps-script/advanced/admin-sdk-directory
[✓] https://developers.google.com/apps-script/concepts/manifests#editing_a_manifest
[✓] https://developers.google.com/apps-script/concepts/scopes#setting_explicit_scopes
[✓] https://developers.google.com/apps-script/reference/script/script-app#getoauthtoken
[✓] samples/NoLibrary
[✓] dist
[✓] samples/Add-on/Callback.html#L47
[✓] https://developers.google.com/apps-script/reference/properties/properties-service
[✓] https://developers.google.com/gmail/add-ons/
[✓] http://googleworkspace.github.io/apps-script-oauth2/Service_.html
[✓] samples/FitBit.gs
[✓] https://smartsheet-platform.github.io/api-docs/#request-an-access-token
[✓] samples/Smartsheet.gs
[✓] https://tools.ietf.org/html/draft-ietf-oauth-jwt-bearer-12
[✓] https://developers.google.com/identity/protocols/OAuth2ServiceAccount#delegatingauthority
[✓] samples/GoogleServiceAccount.gs
[✓] samples/TwitterAppOnly.gs

21 links checked.
```