### PR TITLE
add scope to linkedin example

### DIFF
--- a/samples/LinkedIn.gs
+++ b/samples/LinkedIn.gs
@@ -42,7 +42,10 @@ function getService() {
       // Set the client ID and secret.
       .setClientId(CLIENT_ID)
       .setClientSecret(CLIENT_SECRET)
-
+      
+      // Set the scope of the request.
+      .setScope('r_network')
+      
       // Set the name of the callback function that should be invoked to
       // complete the OAuth flow.
       .setCallbackFunction('authCallback')


### PR DESCRIPTION
Linkedin has started [requiring](https://docs.microsoft.com/en-us/linkedin/shared/authentication/authorization-code-flow#step-2-request-an-authorization-code) the scope to be passed in with the request. The People V1 API requires the [r_network](https://developer.linkedin.com/docs/v1/people/connections-api) scope. This change adds it to the authentication flow.