### PR TITLE
Update Google sample

### DIFF
--- a/samples/Google.gs
+++ b/samples/Google.gs
@@ -58,7 +58,7 @@ function getService() {
       // Set the scope and additional Google-specific parameters.
       .setScope('https://www.googleapis.com/auth/drive')
       .setParam('access_type', 'offline')
-      .setParam('approval_prompt', 'force')
+      .setParam('prompt', 'consent')
       .setParam('login_hint', Session.getActiveUser().getEmail());
 }
 


### PR DESCRIPTION
Current version sample Google.gs not return refresh_token on request. I.e. always refresh_token=null.
A similar issue:  https://github.com/googleapis/google-api-dotnet-client/issues/1185