### PR TITLE
Adds entrypoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,5 +37,6 @@
     "doc": "jsdoc -c jsdoc.json src/*.js README.md",
     "push": "cd src; clasp push",
     "test": "mocha"
-  }
+  },
+  "exports": "./dist/OAuth2.gs"
 }


### PR DESCRIPTION
As a developer building a GAS project using ES modules (import/export), I would like to be able to `import` this package:

```
import { OAuth2 } from 'OAuth2';
```

Currently, this fails with an error like so:

```
Module not found: Error: Can't resolve 'OAuth2' in '/Users/nathan/.../src'

Field 'browser' doesn't contain a valid alias configuration
```

After declaring an entry-point for this package (via package.json), then I am able to `import` the package without error.


