### PR TITLE
Fix issue with refresh tokens in the Dropbox sample

### DIFF
--- a/samples/Dropbox.gs
+++ b/samples/Dropbox.gs
@@ -53,8 +53,8 @@ function getService_() {
       // Set the property store where authorized tokens should be persisted.
       .setPropertyStore(PropertiesService.getUserProperties())
 
-      // Set the response type to code (required).
-      .setParam('response_type', 'code');
+      // Enable offline access (refresh_token).
+      .setParam('token_access_type', 'offline');
 }
 
 /**


### PR DESCRIPTION
See the [Dropbox OAuth documentation](https://developers.dropbox.com/oauth-guide#:~:text=Note%3A%20you%E2%80%99ll%20need%20to%20include%C2%A0token_access_type%3Doffline%20as%20a%20parameter%20on%20your%20Authorization%20URL%20in%20order%20to%20return%20a%20refresh_token%20inside%20your%20access%20token%20payload.). Fixes #434.