### PR TITLE
Add support for refresh_expires_in (#358)

### DIFF
--- a/src/Service.js
+++ b/src/Service.js
@@ -653,7 +653,8 @@ Service_.prototype.ensureExpiresAtSet_ = function(token) {
     var expiresAt = grantedTime + Number(expiresIn);
     token.expiresAt = expiresAt;
   }
-  var refreshTokenExpiresIn = token.refresh_token_expires_in;
+  var refreshTokenExpiresIn = token.refresh_token_expires_in ||
+    token.refresh_expires_in;
   if (refreshTokenExpiresIn) {
     var refreshTokenExpiresAt = grantedTime + Number(refreshTokenExpiresIn);
     token.refreshTokenExpiresAt = refreshTokenExpiresAt;


### PR DESCRIPTION
This is referenced in some OAuth documentation including:
* https://developer.cisco.com/docs/firepower-device-manager/#!authenticating-your-rest-api-client-using-oauth/requesting-a-custom-access-token
* https://www.ibm.com/docs/en/api-connect/2018.x?topic=settings-configuring-timeouts-access-tokens-refresh-tokens