### PR TITLE
fix: issue with refreshing token when client_secret is not set

### DIFF
--- a/dist/OAuth2.gs
+++ b/dist/OAuth2.gs
@@ -759,7 +759,6 @@ Service_.prototype.ensureExpiresAtSet_ = function(token) {
 Service_.prototype.refresh = function() {
   validate_({
     'Client ID': this.clientId_,
-    'Client Secret': this.clientSecret_,
     'Token URL': this.tokenUrl_
   });
 

--- a/src/Service.js
+++ b/src/Service.js
@@ -666,7 +666,6 @@ Service_.prototype.ensureExpiresAtSet_ = function(token) {
 Service_.prototype.refresh = function() {
   validate_({
     'Client ID': this.clientId_,
-    'Client Secret': this.clientSecret_,
     'Token URL': this.tokenUrl_
   });
 

--- a/test/test.js
+++ b/test/test.js
@@ -387,11 +387,14 @@ describe('Service', () => {
       done();
     });
 
-    it('should refresh token granted for PKCE', (done) => {
+    it('should refresh token granted for PKCE', () => {
+      const NOW_SECONDS = OAuth2.getTimeInSeconds_(new Date());
+      const ONE_HOUR_AGO_SECONDS = NOW_SECONDS - 360;
       var token = {
-        granted_time: 100,
-        expires_in: 0,
-        refresh_token: 'bar'
+        granted_time: ONE_HOUR_AGO_SECONDS,
+        expires_in: 100,
+        refresh_token: 'bar',
+        refresh_token_expires_in: 720
       };
       var properties = new MockProperties({
         'oauth2.test': JSON.stringify(token)
@@ -405,11 +408,12 @@ describe('Service', () => {
           .setClientId('test')
           .setTokenUrl('http://www.example.com')
           .setPropertyStore(properties)
+          .generateCodeVerifier()
           .refresh();
 
       var storedToken = JSON.parse(properties.getProperty('oauth2.test'));
       assert.equal(storedToken.refresh_token, 'bar');
-      done();
+      assert.equal(storedToken.refreshTokenExpiresAt, NOW_SECONDS + 360);
     });
 
     it('should retain refresh expiry', () => {

--- a/test/test.js
+++ b/test/test.js
@@ -387,6 +387,31 @@ describe('Service', () => {
       done();
     });
 
+    it('should refresh token granted for PKCE', (done) => {
+      var token = {
+        granted_time: 100,
+        expires_in: 0,
+        refresh_token: 'bar'
+      };
+      var properties = new MockProperties({
+        'oauth2.test': JSON.stringify(token)
+      });
+
+      mocks.UrlFetchApp.resultFunction = () => JSON.stringify({
+        access_token: Math.random().toString(36)
+      });
+
+      OAuth2.createService('test')
+          .setClientId('test')
+          .setTokenUrl('http://www.example.com')
+          .setPropertyStore(properties)
+          .refresh();
+
+      var storedToken = JSON.parse(properties.getProperty('oauth2.test'));
+      assert.equal(storedToken.refresh_token, 'bar');
+      done();
+    });
+
     it('should retain refresh expiry', () => {
       const NOW_SECONDS = OAuth2.getTimeInSeconds_(new Date());
       const ONE_HOUR_AGO_SECONDS = NOW_SECONDS - 360;


### PR DESCRIPTION
Fix for https://github.com/googleworkspace/apps-script-oauth2/issues/506

**Problem**: The support for PKCE (Proof Key for Code Exchange) was introduced in the library, making the `client_secret` field optional (see commit [e6afdfb](https://github.com/googleworkspace/apps-script-oauth2/commit/e6afdfb52d613f4e99002bf72228b32a7299cfc7)). However, the `client_secret` field is still included in the list of validated fields in the `refresh()` method ([Service.js#L667](https://github.com/googleworkspace/apps-script-oauth2/blob/main/src/Service.js#L667)).

**Issue**: When creating a client without setting a `client_secret` (using PKCE for authentication), the token cannot be refreshed after its default expiration of one hour. This is because the validation check in the `refresh()` method expects a `client_secret`, causing an error in the PKCE flow.

**Proposed Fix**: Adjust the validation logic in the `refresh()` method to account for the possibility that the `client_secret` is not provided when using PKCE. This ensures that the token can still be refreshed in the absence of a `client_secret`.
